### PR TITLE
Use generator instead of list comprehension

### DIFF
--- a/pf/yatzy/yatzy.py
+++ b/pf/yatzy/yatzy.py
@@ -22,7 +22,7 @@ def score_ones(dice):
 
 
 def score_twos(dice):
-    return sum([d for d in dice if d == 2])
+    return sum(d for d in dice if d == 2)
 
 
 def score_threes(dice):


### PR DESCRIPTION
When calling sum(), there's no need to pre-evaluate its argument
into a list, when a generator will do just fine.
